### PR TITLE
fix getopt return value type

### DIFF
--- a/slurm-spank-x11.c
+++ b/slurm-spank-x11.c
@@ -183,7 +183,7 @@ int main(int argc,char** argv)
 	char* optstring = "hi:crgwf:t:pd:u:s:o:";
 	char* short_options_desc = "Usage : %s [-h] -i refid [-g|c|r] [-w] \n\[-u user] [-t nodeB"
 		" [-f nodeA [-d display]] [-s ssh_cmd] [-o ssh_args] ] \n";
-	char  option;
+	int   option;
 	char* addon_options_desc="\n\
         -h\t\tshow this message\n\
         -i refid\tjob id to use as a reference\n\


### PR DESCRIPTION
getopt returns an int, not a char (and ARM chars are unsigned by default).
