### PR TITLE
Fix compile warning.

### DIFF
--- a/slurm-spank-x11-plug.c
+++ b/slurm-spank-x11-plug.c
@@ -204,7 +204,7 @@ int slurm_spank_local_user_init (spank_t sp, int ac, char **av)
 
 	/* check DISPLAY value */
 	if ( getenv("DISPLAY") == NULL ) {
-		ERROR("x11: no local DISPLAY defined, skipping",jobid);
+		ERROR("x11: no local DISPLAY defined, skipping");
 		return 0;
 	}
 


### PR DESCRIPTION
```
brian@compy:~/slurm/slurm-spank-x11$ gcc -g -shared -fPIC -o x11.so \
>         -I/home/brian/slurm/14.11/centos6/slurm/ \
>         -I/home/brian/slurm/14.11/slurm/ \
>         -D"X11_LIBEXEC_PROG=\"/home/brian/slurm/14.11/centos6/libexec/slurm-spank-x11\"" \
>         slurm-spank-x11-plug.c
slurm-spank-x11-plug.c: In function ‘slurm_spank_local_user_init’:
slurm-spank-x11-plug.c:207:3: warning: too many arguments for format [-Wformat-extra-args]
   ERROR("x11: no local DISPLAY defined, skipping",jobid);
   ^
```
